### PR TITLE
reduce the file_methods-file and use the boost-filesystem-library more directly

### DIFF
--- a/include/libKitsunemimiPersistence/files/file_methods.h
+++ b/include/libKitsunemimiPersistence/files/file_methods.h
@@ -13,16 +13,13 @@
 #include <assert.h>
 #include <boost/filesystem.hpp>
 
+namespace bfs = boost::filesystem;
+
 namespace Kitsunemimi
 {
 namespace Persistence
 {
 
-bool doesPathExist(const std::string path);
-bool isFile(const std::string filePath);
-bool isDir(const std::string dirPath);
-
-const std::string getParent(const std::string &path);
 void listFiles(std::vector<std::string> &fileList,
                const std::string &path,
                const bool withSubdirs=true,
@@ -30,20 +27,20 @@ void listFiles(std::vector<std::string> &fileList,
 
 const std::string getRelativePath(const std::string &absolutePath,
                                   const std::string &rootPath);
-const std::string getRelativePath(const std::string &oldRootPath,
-                                  const std::string &oldRelativePath,
-                                  const std::string &newRootPath);
+const bfs::path getRelativePath(const bfs::path &oldRootPath,
+                                const bfs::path &oldRelativePath,
+                                const bfs::path &newRootPath);
 
-bool renameFileOrDir(const std::string &oldPath,
-                     const std::string &newPath,
+bool renameFileOrDir(const bfs::path &oldPath,
+                     const bfs::path &newPath,
                      std::string &errorMessage);
-bool copyPath(const std::string &sourcePath,
-              const std::string &targetPath,
+bool copyPath(const bfs::path &sourcePath,
+              const bfs::path &targetPath,
               std::string &errorMessage,
               const bool force=true);
-bool createDirectory(const std::string &path,
+bool createDirectory(const bfs::path &path,
                      std::string &errorMessage);
-bool deleteFileOrDir(const std::string &path,
+bool deleteFileOrDir(const bfs::path &path,
                      std::string &errorMessage);
 
 

--- a/src/files/file_methods.cpp
+++ b/src/files/file_methods.cpp
@@ -14,71 +14,6 @@ namespace Persistence
 {
 
 /**
- * @brief check if a path exist
- *
- * @param path path to check
- *
- * @return true, if path exist, else false
- */
-bool
-doesPathExist(const std::string path)
-{
-    return boost::filesystem::exists(path);
-}
-
-/**
- * @brief check if a path exist and is a directory
- *
- * @param filePath path to check
- *
- * @return true, if path exist and is a file, else false
- */
-bool
-isFile(const std::string filePath)
-{
-    if(boost::filesystem::exists(filePath) == false
-            || boost::filesystem::is_regular(filePath) == false)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * @brief check if a path exist and is a directory
- *
- * @param dirPath path to check
- *
- * @return true, if path exist and is a directory, else false
- */
-bool
-isDir(const std::string dirPath)
-{
-    if(boost::filesystem::exists(dirPath) == false
-            || boost::filesystem::is_directory(dirPath) == false)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * @brief get parent-path of a path
- *
- * @param path original path
- *
- * @return parent-path
- */
-const std::string
-getParent(const std::string &path)
-{
-    boost::filesystem::path pathObj(path);
-    return pathObj.parent_path().string();
-}
-
-/**
  * @brief iterate over a directory and subdirectory to file all containing files
  *
  * @param fileList resulting string-list with the absolute path of all found files
@@ -155,27 +90,6 @@ listFiles(std::vector<std::string> &fileList,
 }
 
 /**
- * @brief get relative path of one to another
- *
- * @param absolutePath absolute path
- * @param absolutePath root path
- *
- * @return relative path of the absolute path in relation to the root
- */
-const std::string
-getRelativePath(const std::string &absolutePath,
-                const std::string &rootPath)
-{
-    std::string newRoot = rootPath;
-
-    if(newRoot.at(newRoot.size()-1) == '/') {
-        newRoot = rootPath.substr(0, rootPath.size()-1);
-    }
-
-    return boost::filesystem::relative(absolutePath, newRoot).string();
-}
-
-/**
  * @brief get ralative path in relation to a new root-path
  *
  * @param oldRootPath old root-path
@@ -184,16 +98,14 @@ getRelativePath(const std::string &absolutePath,
  *
  * @return new relative path
  */
-const std::string
-getRelativePath(const std::string &oldRootPath,
-                const std::string &oldRelativePath,
-                const std::string &newRootPath)
+const bfs::path
+getRelativePath(const bfs::path &oldRootPath,
+                const bfs::path &oldRelativePath,
+                const bfs::path &newRootPath)
 {
-    boost::filesystem::path realtivePathObj(oldRelativePath);
-    boost::filesystem::path oringinPathObj(oldRootPath);
-    boost::filesystem::path completePath = oringinPathObj / realtivePathObj;
+    boost::filesystem::path completePath = oldRootPath / oldRelativePath;
 
-    return getRelativePath(completePath.string(), newRootPath);
+    return bfs::relative(completePath, newRootPath);
 }
 
 /**
@@ -206,13 +118,13 @@ getRelativePath(const std::string &oldRootPath,
  * @return true, if successful, else false
  */
 bool
-renameFileOrDir(const std::string &oldPath,
-                const std::string &newPath,
+renameFileOrDir(const bfs::path &oldPath,
+                const bfs::path &newPath,
                 std::string &errorMessage)
 {
-    if(doesPathExist(oldPath) == false)
+    if(bfs::exists(oldPath) == false)
     {
-        errorMessage = "source-path " + oldPath + " doesn't exist.";
+        errorMessage = "source-path " + oldPath.string() + " doesn't exist.";
         return false;
     }
 
@@ -240,14 +152,14 @@ renameFileOrDir(const std::string &oldPath,
  * @return true, if successful, else false
  */
 bool
-copyPath(const std::string &sourcePath,
-         const std::string &targetPath,
+copyPath(const bfs::path &sourcePath,
+         const bfs::path &targetPath,
          std::string &errorMessage,
          const bool force)
 {
-    if(doesPathExist(sourcePath) == false)
+    if(bfs::exists(sourcePath) == false)
     {
-        errorMessage = "source-path " + sourcePath + " doesn't exist.";
+        errorMessage = "source-path " + sourcePath.string() + " doesn't exist.";
         return false;
     }
 
@@ -275,12 +187,15 @@ copyPath(const std::string &sourcePath,
  * @return true, if successful, else false
  */
 bool
-createDirectory(const std::string &path,
+createDirectory(const bfs::path &path,
                 std::string &errorMessage)
 {
-    if(isFile(path))
+    if(bfs::exists(path)
+            && bfs::is_regular_file(path))
     {
-        errorMessage = "under path " + path + " a file already exist.";
+        errorMessage = "under path "
+                       + path.string()
+                       + " a file already exist.";
         return false;
     }
 
@@ -303,10 +218,10 @@ createDirectory(const std::string &path,
  * @return true, if successful, else false. Also return true, if path is already deleted.
  */
 bool
-deleteFileOrDir(const std::string &path,
+deleteFileOrDir(const bfs::path &path,
                 std::string &errorMessage)
 {
-    if(doesPathExist(path) == false) {
+    if(bfs::exists(path) == false) {
         return true;
     }
 

--- a/src/files/text_file.cpp
+++ b/src/files/text_file.cpp
@@ -34,10 +34,10 @@ readFile(std::string &readContentconst,
          std::string &errorMessage)
 {
     // check if exist
-    if(doesPathExist(filePath))
+    if(bfs::exists(filePath))
     {
         // check for directory
-        if(isDir(filePath))
+        if(bfs::is_directory(filePath))
         {
             errorMessage = "failed to read destination of path \""
                            + filePath +
@@ -81,8 +81,8 @@ writeFile(const std::string &filePath,
           const bool force)
 {
     // check and create parent-directory, if necessary
-    const std::string parentDirectory = getParent(filePath);
-    if(doesPathExist(parentDirectory) == false)
+    const bfs::path parentDirectory = bfs::path(filePath).parent_path();
+    if(bfs::exists(parentDirectory) == false)
     {
         bool result = createDirectory(parentDirectory, errorMessage);
         if(result == false) {
@@ -91,10 +91,10 @@ writeFile(const std::string &filePath,
     }
 
     // check if exist
-    if(doesPathExist(filePath))
+    if(bfs::exists(filePath))
     {
         // check for directory
-        if(isDir(filePath))
+        if(bfs::is_directory(filePath))
         {
             errorMessage = "failed to write destination of path \""
                            + filePath +
@@ -146,7 +146,7 @@ appendText(const std::string &filePath,
            std::string &errorMessage)
 {
     // check for directory
-    if(isFile(filePath) == false)
+    if(bfs::is_regular_file(filePath) == false)
     {
         errorMessage = "Failed to append text to file \""
                        + filePath +

--- a/tests/unit_tests/libKitsunemimiPersistence/files/file_methods_test.cpp
+++ b/tests/unit_tests/libKitsunemimiPersistence/files/file_methods_test.cpp
@@ -37,103 +37,11 @@ namespace Persistence
 FileMethods_Test::FileMethods_Test()
     : Kitsunemimi::CompareTestHelper("FileMethods_Test")
 {
-    doesPathExist_test();
-    isFile_test();
-    isDir_test();
-    getParent_test();
     listFiles_test();
-    getRelativePath_test();
     renameFileOrDir_test();
     copyPath_test();
     createDirectory_test();
     deleteFileOrDir_test();
-}
-
-/**
- * @brief doesPathExist_test
- */
-void
-FileMethods_Test::doesPathExist_test()
-{
-    const std::string testPath = "/tmp/doesPathExist_test_testfile";
-    runSyncProcess(std::string("rm " + testPath).c_str());
-
-    TEST_EQUAL(doesPathExist(testPath), false);
-
-    runSyncProcess(std::string("touch " + testPath).c_str());
-
-    TEST_EQUAL(doesPathExist(testPath), true);
-
-    runSyncProcess(std::string("rm " + testPath).c_str());
-}
-
-/**
- * @brief isFile_test
- */
-void
-FileMethods_Test::isFile_test()
-{
-    const std::string testFilePath = "/tmp/isFile_test_testfile";
-    const std::string testDirPath = "/tmp/isFile_test_testdir";
-
-    runSyncProcess(std::string("rm " + testFilePath).c_str());
-    runSyncProcess(std::string("rm -r " + testDirPath).c_str());
-
-    TEST_EQUAL(isFile(testFilePath), false);
-    TEST_EQUAL(isFile(testDirPath), false);
-
-    runSyncProcess(std::string("touch " + testFilePath).c_str());
-    runSyncProcess(std::string("mkdir " + testDirPath).c_str());
-
-    TEST_EQUAL(isFile(testFilePath), true);
-    TEST_EQUAL(isFile(testDirPath), false);
-
-    runSyncProcess(std::string("rm " + testFilePath).c_str());
-    runSyncProcess(std::string("rm -r " + testDirPath).c_str());
-}
-
-/**
- * @brief isDir_test
- */
-void
-FileMethods_Test::isDir_test()
-{
-    const std::string testFilePath = "/tmp/isDir_test_testfile";
-    const std::string testDirPath = "/tmp/isDir_test_testdir";
-
-    runSyncProcess(std::string("rm " + testFilePath).c_str());
-    runSyncProcess(std::string("rm -r " + testDirPath).c_str());
-
-    TEST_EQUAL(isDir(testFilePath), false);
-    TEST_EQUAL(isDir(testDirPath), false);
-
-    runSyncProcess(std::string("touch " + testFilePath).c_str());
-    runSyncProcess(std::string("mkdir " + testDirPath).c_str());
-
-    TEST_EQUAL(isDir(testFilePath), false);
-    TEST_EQUAL(isDir(testDirPath), true);
-
-    runSyncProcess(std::string("rm " + testFilePath).c_str());
-    runSyncProcess(std::string("rm -r " + testDirPath).c_str());
-}
-
-/**
- * @brief getParent_test
- */
-void
-FileMethods_Test::getParent_test()
-{
-    const std::string testFilePath = "/tmp/isFile_test_testdir/isFile_test_testfile";
-    const std::string testDirPath = "/tmp/isFile_test_testdir";
-
-    runSyncProcess(std::string("mkdir " + testDirPath).c_str());
-    runSyncProcess(std::string("touch " + testFilePath).c_str());
-
-    TEST_EQUAL(getParent(testFilePath), testDirPath);
-    TEST_EQUAL(getParent(testDirPath), std::string("/tmp"));
-
-    runSyncProcess(std::string("rm " + testFilePath).c_str());
-    runSyncProcess(std::string("rm -r " + testDirPath).c_str());
 }
 
 /**
@@ -179,32 +87,6 @@ FileMethods_Test::listFiles_test()
 }
 
 /**
- * @brief getRelativePath_test
- */
-void
-FileMethods_Test::getRelativePath_test()
-{
-    std::string child = "/tmp/asdf/poi/meh.txt";
-    std::string parent = "/tmp/asdf/";
-
-    const std::string relative = getRelativePath(child, parent);
-
-    TEST_EQUAL(relative, "poi/meh.txt");
-
-
-
-    std::string oldRelativePath = "../poi/meh.txt";
-    std::string oldRootPath = "/tmp/asdf/";
-    std::string newRootPath = "/tmp/xyz";
-
-    const std::string newRelativePath = getRelativePath(oldRootPath,
-                                                        oldRelativePath,
-                                                        newRootPath);
-
-    TEST_EQUAL(newRelativePath, "../poi/meh.txt");
-}
-
-/**
  * @brief renameFileOrDir_test
  */
 void
@@ -226,8 +108,8 @@ FileMethods_Test::renameFileOrDir_test()
     result = renameFileOrDir(oldFilePath, newFileName, errorMessage);
     TEST_EQUAL(result, false);
 
-    TEST_EQUAL(doesPathExist(oldFilePath), false);
-    TEST_EQUAL(doesPathExist(newFileName), true);
+    TEST_EQUAL(bfs::exists(oldFilePath), false);
+    TEST_EQUAL(bfs::exists(newFileName), true);
 
     runSyncProcess(std::string("rm " + oldFilePath).c_str());
     runSyncProcess(std::string("rm " + newFileName).c_str());
@@ -255,8 +137,8 @@ FileMethods_Test::copyPath_test()
     result = copyPath(oldFilePath, newFileName, errorMessage, false);
     TEST_EQUAL(result, false);
 
-    TEST_EQUAL(doesPathExist(oldFilePath), true);
-    TEST_EQUAL(doesPathExist(newFileName), true);
+    TEST_EQUAL(bfs::exists(oldFilePath), true);
+    TEST_EQUAL(bfs::exists(newFileName), true);
 
     runSyncProcess(std::string("rm " + oldFilePath).c_str());
     runSyncProcess(std::string("rm " + newFileName).c_str());
@@ -273,14 +155,14 @@ FileMethods_Test::createDirectory_test()
     const std::string testDirPath = "/tmp/deleteFileOrDir_test_testdir/test1";
 
     runSyncProcess(std::string("rm -r " + testDirPath).c_str());
-    TEST_EQUAL(doesPathExist(testDirPath), false);
+    TEST_EQUAL(bfs::exists(testDirPath), false);
 
     std::string errorMessage = "";
 
     result = createDirectory(testDirPath, errorMessage);
     TEST_EQUAL(result, true);
 
-    TEST_EQUAL(doesPathExist(testDirPath), true);
+    TEST_EQUAL(bfs::exists(testDirPath), true);
 
     result = createDirectory(testDirPath, errorMessage);
     TEST_EQUAL(result, false);
@@ -304,8 +186,8 @@ FileMethods_Test::deleteFileOrDir_test()
 
     std::string errorMessage = "";
 
-    TEST_EQUAL(doesPathExist(testFilePath), true);
-    TEST_EQUAL(doesPathExist(testDirPath), true);
+    TEST_EQUAL(bfs::exists(testFilePath), true);
+    TEST_EQUAL(bfs::exists(testDirPath), true);
 
     result = deleteFileOrDir(testFilePath, errorMessage);
     TEST_EQUAL(result, true);
@@ -316,8 +198,8 @@ FileMethods_Test::deleteFileOrDir_test()
     result = deleteFileOrDir(testDirPath, errorMessage);
     TEST_EQUAL(result, true);
 
-    TEST_EQUAL(doesPathExist(testFilePath), false);
-    TEST_EQUAL(doesPathExist(testDirPath), false);
+    TEST_EQUAL(bfs::exists(testFilePath), false);
+    TEST_EQUAL(bfs::exists(testDirPath), false);
 
     runSyncProcess(std::string("rm " + testFilePath).c_str());
     runSyncProcess(std::string("rm -r " + testDirPath).c_str());

--- a/tests/unit_tests/libKitsunemimiPersistence/files/file_methods_test.h
+++ b/tests/unit_tests/libKitsunemimiPersistence/files/file_methods_test.h
@@ -37,12 +37,7 @@ public:
     FileMethods_Test();
 
 private:
-    void doesPathExist_test();
-    void isFile_test();
-    void isDir_test();
-    void getParent_test();
     void listFiles_test();
-    void getRelativePath_test();
     void renameFileOrDir_test();
     void copyPath_test();
     void createDirectory_test();


### PR DESCRIPTION
## Description

reduce the file_methods-file and use the boost-filesystem-library more directly

## Related Issues

- #57 

## How it was tested?

- updated unit-tests